### PR TITLE
clientlibs-root deployment path change

### DIFF
--- a/editor/bundle/pom.xml
+++ b/editor/bundle/pom.xml
@@ -163,7 +163,7 @@
           <bnd>
             Sling-Initial-Content: \
               SLING-INF/app-root;overwrite:=true;ignoreImportProviders:=xml;path:=/apps/wcm-io/caconfig/editor,\
-              SLING-INF/clientlibs-root;overwrite:=true;ignoreImportProviders:=xml;path:=/etc/clientlibs/wcm-io/caconfig/editor
+              SLING-INF/clientlibs-root;overwrite:=true;ignoreImportProviders:=xml;path:=/apps/clientlibs/wcm-io/caconfig/editor
 
             Sling-Model-Packages: \
               io.wcm.caconfig.editor.model


### PR DESCRIPTION
clientlibs-root and app-root both should get deployed into /apps node.
clientlibs-root should get deployed into apps/clientlibs instead of /etc/clientlibs node